### PR TITLE
add_styles_CalculatorComponents

### DIFF
--- a/src/components/ClearBtn.js
+++ b/src/components/ClearBtn.js
@@ -1,7 +1,15 @@
 import React, { PropTypes } from 'react';
 
 const ClearBtn = ({ onClick }) => (
-  <button onClick={ onClick }>C</button>
+  <button onClick={ onClick } style={{
+    color:'rgb(50, 150, 250)',
+    backgroundColor: 'rgba(3, 169, 244, 0.08)',
+    borderRadius: '33%',
+    width: '30px',
+    height: '30px',
+    margin: '1px',
+    border: 'outset rgb(50,150,250)',
+  }}>C</button>
 )
 
 ClearBtn.propTypes = {

--- a/src/components/MinusBtn.js
+++ b/src/components/MinusBtn.js
@@ -1,7 +1,15 @@
 import React, { PropTypes } from 'react';
 
 const MinusBtn = ({ onClick }) => (
-  <button onClick={ onClick }>-</button>
+  <button onClick={ onClick } style={{
+    color:'rgb(50, 150, 250)',
+    backgroundColor: 'rgba(3, 169, 244, 0.08)',
+    borderRadius: '33%',
+    width: '30px',
+    height: '30px',
+    margin: '1px',
+    border: 'outset rgb(50,150,250)',
+  }}>-</button>
 )
 
 MinusBtn.propTypes = {

--- a/src/components/NumBtn.js
+++ b/src/components/NumBtn.js
@@ -1,7 +1,15 @@
 import React, { PropTypes } from 'react';
 
 const NumBtn = ({n, onClick}) => (
-  <button onClick={onClick}>{n}</button>
+  <button onClick={onClick} style={{
+    color:'rgb(50, 150, 250)',
+    backgroundColor: 'rgba(3, 169, 244, 0.08)',
+    borderRadius: '33%',
+    width: '30px',
+    height: '30px',
+    margin: '1px',
+    border: 'outset rgb(50,150,250)',
+  }}>{n}</button>
 )
 
 NumBtn.propTypes = {

--- a/src/components/PlusBtn.js
+++ b/src/components/PlusBtn.js
@@ -1,7 +1,15 @@
 import React, { PropTypes } from 'react';
 
 const PlusBtn = ({ onClick }) => (
-  <button onClick={ onClick }>+</button>
+  <button onClick={ onClick } style={{
+    color:'rgb(50, 150, 250)',
+    backgroundColor: 'rgba(3, 169, 244, 0.08)',
+    borderRadius: '33%',
+    width: '30px',
+    height: '30px',
+    margin: '1px',
+    border: 'outset rgb(50,150,250)',
+  }}>+</button>
 )
 
 PlusBtn.propTypes = {

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -7,6 +7,15 @@ const Result = ({ result }, maxLength) => (
       type="text"
       value={result}
       maxLength={maxLength}
+      style={{
+        borderRadius: '5%',
+        border: 'outset rgb(50,150,250)',
+        textAlign: 'right',
+        width: '120px',
+        height: '15px',
+        color: 'rgb(50,150,250)',
+        backgroundColor: 'rgba(3, 169, 244, 0.05)',
+      }}
     />
   </div>
 )


### PR DESCRIPTION
## calculator_componentsにstyleを追加しました。
- カラー　⇒　イメージカラーの水色多め
### ちなみに、スタイルはdev-toolで試してからやると効率がすごく良い
- 特に、色は色彩表？から視覚的に選べるのですごく便利だった